### PR TITLE
chore: remove cron schedule from deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-  schedule:
-    - cron: "30 2 * * 0"
-
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
Removes the weekly cron schedule. Action now only runs on push to main.