### PR TITLE
feat: add GA4 analytics, cookie consent, and blog-only feedback widget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Sync dependencies
         run: uv sync --frozen
 
+      - name: Inject GA4 measurement ID
+        run: sed -i "s/__GA4_PLACEHOLDER__/${{ secrets.GA4_MEASUREMENT_ID }}/g" mkdocs.yml
+
       - name: Build docs
         run: uv run mkdocs build
 

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,2 +1,7 @@
+---
+hide:
+  - feedback
+---
+
 # Blog
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ---
 # template: home.html FIXME: Have a better page layout, if time allows ?
 title: Sanji
+hide:
+  - feedback
 social:
   cards_layout_options:
     title: Sanji by Prateek Rai

--- a/docs/projects/doc-aid/index.md
+++ b/docs/projects/doc-aid/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - feedback
+---
+
 # Doc Aid
 
 !!! note "Coming Soon"

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - feedback
+---
+
 # Projects
 
 <div class="grid cards" markdown>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,29 @@ markdown_extensions:
 
 # Extra Configuration
 extra:
+  consent:
+    title: Cookie Consent
+    description: >-
+      This site uses Google Analytics to understand how it's used.
+      No personal data is collected. You can accept or decline below.
+    cookies:
+      analytics: Google Analytics
+  analytics:
+    provider: google
+    property: __GA4_PLACEHOLDER__
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback!
   # generator: false (https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#generator-notice)
   social:
     - icon: fontawesome/brands/linkedin


### PR DESCRIPTION
## Summary

- Added Google Analytics 4 tracking with MkDocs Material's native integration
- Added cookie consent banner with custom message (required for GA4 GDPR compliance)
- Added "Was this page helpful?" feedback widget (happy/sad emoji ratings) — visible only on blog posts
- Hidden feedback widget on homepage, projects, and blog listing pages
- GA4 property ID is injected via GitHub secret (`GA4_MEASUREMENT_ID`) at build time using a `sed` placeholder — no secrets in the repo

## Setup Required

Before merging, add the repository secret:
1. Go to Settings → Secrets and variables → Actions → New repository secret
2. Name: `GA4_MEASUREMENT_ID`
3. Value: your GA4 measurement ID (G-XXXXXXXXXX)