### PR TITLE
feat: enhance agent framework & site identity

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -6,10 +6,11 @@ This directory contains conventions and tooling for maintaining consistent blog 
 
 | File | Purpose |
 |------|---------|
-| `.agents/rules/blog-rules.md` | All writing conventions: front matter, tone, code blocks, images, secrets |
-| `.agents/patterns/blog-patterns.md` | Post architecture templates (Technical Guide, Character Analysis, Extension) |
+| `.agents/rules/blog-rules.md` | All writing conventions: front matter, tone, code blocks, images, secrets, OP theming, trivia, handoff docs |
+| `.agents/patterns/blog-patterns.md` | Post architecture templates (Technical Guide, Character Analysis, Extension, Rant + One Piece) |
 | `.agents/skills/write-blog-post.md` | Step-by-step workflow for generating a new post |
-| `.agents/commands/new-blog.md` | Quick reference for creating and verifying posts |
+| `.agents/commands/new-blog.md` | Executable workflow for creating posts, optionally from handoff docs |
+| `.agents/handoffs/` | Directory for handoff docs — Agent A drops project notes here, Agent B consumes them |
 
 ## Critical Rules
 
@@ -18,3 +19,14 @@ This directory contains conventions and tooling for maintaining consistent blog 
 - Place images in `docs/assets/images/<slug>/` before referencing them
 - Image paths are relative: `../../assets/images/<slug>/file.jpg`
 - Author is always `prateek11rai` (configured in `docs/blog/.authors.yml`)
+- Every post needs One Piece intro image + closing image + one thematic reference (minimum)
+- Handoff docs decouple project work from blog writing — use `.agents/handoffs/<slug>.md`
+
+## Workflow with Handoff Docs
+
+```mermaid
+graph LR
+    A[Agent A: Builds<br/>the project] -->|writes| H[.agents/handoffs/&lt;slug&gt;.md]
+    H -->|consumed by| B[Agent B: Runs<br/>new-blog command]
+    B -->|drafts| P[docs/blog/posts/&lt;slug&gt;.md]
+```

--- a/.agents/commands/new-blog.md
+++ b/.agents/commands/new-blog.md
@@ -1,20 +1,108 @@
 # New Blog Post Workflow
 
-Run these steps in order when creating a new blog post:
+Run this when asked to write a new blog post. Follow the steps in order.
 
-## 1. Create the post file
+## Usage
 
+```bash
+# Without handoff doc (agent knows the topic)
+new-blog <topic-slug>
+
+# With handoff doc from another agent
+new-blog <topic-slug> <path-to-handoff-doc>
 ```
+
+## Step-by-Step
+
+### Step 1: Accept Inputs
+
+- `slug` — lowercase, hyphenated, matches the filename (e.g. `wezterm-tmux-setup`)
+- `handoff_doc` — optional path to a `.md` file produced by another agent who did the project work
+
+### Step 2: Read Handoff Doc (if provided)
+
+If a handoff doc exists at `.agents/handoffs/<slug>.md` or a custom path, read it. Expect this format:
+
+```markdown
+# Handoff: <Topic>
+
+## What Was Built
+<summary of the project, setup, or workflow>
+
+## Key Decisions
+- <decision 1> — why
+- <decision 2> — why
+
+## Screenshots Available
+- <path/to/screenshot> — what it shows
+
+## One Piece Angle Suggestion
+<which character, island, or theme maps to this>
+
+## Trivia / Hot Takes
+- <interesting detail worth calling out>
+- <strong opinion or rant>
+
+## Config Files / Dotfiles (if relevant)
+- <path/to/file> — what it configures
+```
+
+If no handoff doc exists, gather the same information by asking the user or researching.
+
+### Step 3: Identify the Pattern
+
+Read `.agents/patterns/blog-patterns.md` and pick the best match:
+
+| Post type | Pattern |
+|---|---|
+| First-time setup, hardware, new service | **1: Technical Guide** |
+| Character analysis, opinion piece | **2: Character Analysis** |
+| Follow-up to an existing post | **3: Extension Post** |
+| Tooling, workflow, dotfiles, personal setup | **4: Rant + One Piece** |
+
+For WezTerm/tmux/dotfiles posts, Pattern 4 is the best fit.
+
+### Step 4: Determine the One Piece Angle
+
+Every post needs at least **one** One Piece thread. Spend 2-3 minutes deciding:
+
+- **Metaphor**: What OP character or concept parallels the tech? (e.g. Ohara = knowledge preservation, Sanji = chef/craft, Franky = shipwright/builder, Chopper = medicine/health, Nami = navigation/mapping)
+- **Intro image**: Must be OP-themed. Sources: official art from wiki, fanart from Pinterest, manga panels from Reddit.
+- **Closing image**: OP character that ties the reflection together.
+- **Section tie-ins**: Can a section header or aside reference an OP scene or quote?
+
+### Step 5: Gather Trivia / Hot Takes
+
+Inject 2-3 pieces of personality per post:
+
+- **Trivia**: obscure fact about the tool, a historical footnote, a comparison nobody asked for
+- **Hot take**: strong opinion about why something is overrated/underrated, a setup choice you'd defend in a fight
+- **Rant**: something that annoyed you during the process — permission issues, bad docs, missing features
+
+Place these in admonitions (`!!! tip "Trivia"` or `!!! quote "Hot Take"`) or weave them into section text.
+
+### Step 6: Source Images
+
+- OP intro image: look in `docs/assets/images/` for reuse, else find from web (save to `docs/assets/images/<slug>/`)
+- Closing image: OP character that matches the post's theme
+- Screenshots: provided by user or handoff doc
+- All images get `{ loading=lazy }` and descriptive alt text
+
+### Step 7: Create Files
+
+```bash
+mkdir -p docs/assets/images/<slug>/
 touch docs/blog/posts/<slug>.md
 ```
 
-## 2. Create image directory
+### Step 8: Draft the Post
 
-```
-mkdir docs/assets/images/<slug>/
-```
+Write the post following:
+- `.agents/rules/blog-rules.md` — front matter, tone, code blocks, images, secrets
+- The chosen pattern from `.agents/patterns/blog-patterns.md`
+- One Piece theming and trivia from steps 4-5
 
-## 3. Write the post with front matter:
+Front matter template:
 
 ```yaml
 ---
@@ -27,11 +115,19 @@ draft: false
 ---
 ```
 
-## 4. Verify
+### Step 9: Verify
 
-```
+```bash
 uv run poe build
 ```
+
+Fix any warnings or errors.
+
+## Handoff Doc Convention
+
+Handoff docs live in `.agents/handoffs/<slug>.md`. When Agent A finishes project work, they write a handoff doc there. Agent B (blog writer) reads it via `new-blog <slug> .agents/handoffs/<slug>.md`.
+
+This keeps the project work and the writing decoupled — you can hand off to a different agent or resume days later.
 
 ## Quick Reference
 
@@ -40,4 +136,5 @@ uv run poe build
 | Serve locally | `uv run poe serve` |
 | Build | `uv run poe build` |
 | Create post | `touch docs/blog/posts/<slug>.md` |
-| Create image dir | `mkdir docs/assets/images/<slug>/` |
+| Create image dir | `mkdir -p docs/assets/images/<slug>/` |
+| Handoff dir | `.agents/handoffs/` |

--- a/.agents/patterns/blog-patterns.md
+++ b/.agents/patterns/blog-patterns.md
@@ -10,7 +10,7 @@ Title: Descriptive, benefit-driven ("Breathing Life Into an Old PC: ...")
 
 Structure:
 1. **Opening Hook** — personal anecdote about the problem
-2. **Image** before the break
+2. **Image** — OP-themed intro image before the break
 3. `<!-- more -->`
 4. **Hardware/Context** — what you're working with (grid cards for specs)
 5. **Decision Points** — why you chose X over Y (table or comparison)
@@ -18,12 +18,12 @@ Structure:
 7. **Diagrams** — architecture mermaid for each component
 8. **Client Setup** — how each device connects
 9. **Complete Architecture** — full mermaid diagram showing everything
-10. **Closing** — thematic reflection + checklist of what you'll have
+10. **Closing** — thematic reflection + checklist of what you'll have, tied to OP theme
 
 Image placement:
-- Intro image (before break): hardware or setup photo
+- Intro image (before break): OP-themed or hardware photo
 - Section images: optional, avoid forcing it
-- Closing image: thematic / reflective
+- Closing image: OP character parallel to the reflection
 
 Code density: high. Every section has a runnable code block.
 
@@ -39,7 +39,7 @@ Title: Single-word or short name
 
 Structure:
 1. **Opening** — why this topic matters to you
-2. **Image** before the break
+2. **Image** — before the break
 3. `<!-- more -->`
 4. **Thematic sections** — each explores a different angle of the topic
 5. **Closing** — personal takeaway
@@ -59,7 +59,7 @@ Intended for: posts that build on a previous one (e.g. "Adding X to Ohara")
 
 Structure:
 1. **Opening** — reference the previous post, state what changed
-2. **Image** before the break
+2. **Image** — before the break
 3. `<!-- more -->`
 4. **Context** — what you're adding and why
 5. **Setup** — focused on just the new thing (assumes existing infra from previous post)
@@ -69,6 +69,55 @@ Structure:
 9. **Closing** — what's next
 
 Image placement:
-- Intro image: the new hardware or a thematic photo
+- Intro image: OP-themed or the new hardware
 - Troubleshooting section: screenshots if relevant
 - Architecture diagram: always
+
+---
+
+## Pattern 4: Rant + One Piece (Tooling, Workflow, Dotfiles)
+
+Used in: (intended for `wezterm-tmux-setup` and similar)
+
+```
+Title: "Crafting Your Terminal Like a Chef Sharpens His Knives" — poetic, craft-focused
+```
+
+The idea: this pattern blends a technical walkthrough with the personality of a rant and the visual identity of One Piece. Every section carries a parallel to Sanji's philosophy — tools as craft, setup as ritual, config as personal expression.
+
+Structure:
+1. **Opening Hook** — personal rant about defaults being bad, why you care about this tool
+2. **OP Intro Image** — character or scene that fits the craft theme (Sanji in the kitchen, Franky building, Zoro sharpening swords)
+3. **Why This Tool** — hot take about why the mainstream alternative is overrated (e.g. "iTerm2 is fine if you like bloat"). Compare in a table.
+4. **The Core Setup** — step-by-step config walkthrough. Each subsection ties back to the OP metaphor.
+5. **Trivia Break** — an admonition or footnote with an obscure fact about the tool or its history
+6. **The Dotfiles** — show the actual config files (or key excerpts). Explain why each setting matters.
+7. **Visual Proof** — screenshot of the working setup + OP-themed image that matches the aesthetic
+8. **Rant Section** — dedicated space for a strong opinion. What almost made you quit. What you'd change. Use `!!! quote "Hot Take"`.
+9. **Architecture / Flow** — mermaid diagram showing how the pieces fit (e.g. WezTerm → tmux → zsh → starship)
+10. **Closing** — tie back to the OP character. "Sanji doesn't use a dull knife. Why should you use a default terminal?"
+
+Image placement:
+- Intro: OP character in a craft/creation scene
+- Each major section: optional but encouraged — mix of screenshots and OP art
+- Closing: OP character reflecting on mastery
+
+Code density: medium-high. Config file excerpts, not full files.
+
+One Piece Angle Matrix (for reference):
+
+| Tool/Concept | OP Parallel | Why |
+|---|---|---|
+| Terminal | Sanji's kitchen | Your space, your rules, your tools |
+| tmux | Franky's workshop | Multiplexing = multiple projects at once |
+| WezTerm | Zoro's swords | Configurable, sharp, cuts through lag |
+| Dotfiles | Nami's maps | Navigation through your system |
+| Starship prompt | Chopper's medicine chest | Diagnostic at a glance |
+| Zsh plugins | Robin's bookshelf | Knowledge ready when you need it |
+| Neovim | Sanji's knives | Craftsmanship, precision, personal |
+
+Trivia / Rant Ideas:
+- WezTerm history: why the author built it (GPU-accelerated terminals were all incomplete)
+- tmux vs screen: the ancient war
+- Lua vs TOML configs: opinionated take
+- Your actual hot take about font rendering on macOS

--- a/.agents/rules/blog-rules.md
+++ b/.agents/rules/blog-rules.md
@@ -18,7 +18,7 @@ draft: false
 ```
 
 - Only one author: `prateek11rai`
-- Categories: 1-2 max, PascalCase (e.g. `Self-Hosting`, `Homelab`, `Anime`, `AI`)
+- Categories: 1-2 max, PascalCase (e.g. `Self-Hosting`, `Homelab`, `Anime`, `AI`, `Tooling`)
 - Date: use the actual publication date
 - Never leave `draft: true` for published posts
 
@@ -31,6 +31,7 @@ draft: false
 - This is a personal blog — opinions and personality are encouraged
 - When referencing the server, use its nickname (Ohara) after introducing it
 - Reference One Piece theming when relevant but don't force it
+- **Rant voice is allowed** — if something annoyed you, say it. If you have a hot take, say it. This is a blog, not a documentation project.
 
 ## Post Structure (Body)
 
@@ -45,17 +46,94 @@ draft: false
 
 - Every post needs an intro image (before `<!-- more -->`)
 - Add a closing or thematic image near the end
+- **Intro and closing images should be One Piece themed where possible**
 - Place images within relevant sections, not just at section boundaries
 - Images use relative paths: `../../assets/images/<post-slug>/<filename>.{jpg,png}`
 - Every image gets `{ loading=lazy }`
 - Alt text describes what the image shows
 - Use footnotes for image attribution if sourcing from the web
 
+### One Piece Image Sourcing
+
+- **Intro images**: Find OP art that parallels the topic. Use official art from the One Piece wiki, manga panels (official translation), or high-quality fanart from Pinterest.
+- **Closing images**: A character or scene that reflects the post's theme. Vegapunk for future/ambition, Luffy for freedom/breaking limits, Sanji for craft/mastery, Franky for building, Robin for knowledge.
+- **Section images**: Optional but encouraged. Screenshots of the actual setup work better here than OP art.
+- **Avoid overusing the same character** — rotate through the crew.
+- **Alt-text convention**: Describe the scene AND state the character name: "Sanji lighting a cigarette in the Baratie kitchen, reflecting on craft"
+
 ## Footnotes
 
 - Use `[^1]`, `[^2]` for attribution or minor clarifications
 - Place footnote definitions at the **very bottom** of the file
 - First footnote should be image attribution with contact email
+
+## One Piece Theming Strategy
+
+Every post on this site should feel like part of a series, not an isolated technical article. The OP thread unifies them.
+
+**One Piece visual identity — mandatory:**
+
+1. **Intro image** — OP themed (before `<!-- more -->`)
+2. **Closing image** — OP themed (near the end)
+
+These two images are what make the site feel cohesive. The intro sets the mood, the closing leaves a reflection.
+
+**Thematic reference in text — optional:**
+
+If the tech has a natural parallel to an OP character, event, or island, draw it. If it doesn't, don't force it. Purely technical posts with no anime reference in the body are fine — the images carry the identity.
+
+**How to find the angle (when it fits):**
+- Does the tool "build" something? → Franky
+- Does it "serve" or "preserve"? → Sanji or Ohara
+- Does it explore or navigate? → Nami or Robin
+- Does it fight or overcome limitations? → Luffy or Zoro
+- Does it heal or monitor? → Chopper
+
+**When in doubt, leave it out.** A forced metaphor is worse than none.
+
+## Trivia & Rants
+
+### Trivia Placement
+- Use `!!! tip "Trivia"` or `!!! info "Did You Know?"` admonitions for fun facts
+- Keep them short — one paragraph, directly relevant to the section
+- Examples: historical origin of the tool, naming backstory, a comparison with a dead project
+- **Not required** — only include if you have something genuinely interesting to say
+
+### Rants / Hot Takes
+- Use `!!! quote "Hot Take"` admonitions or weave into section prose
+- Rants are encouraged but **not required**. Only write one if you actually have a strong opinion.
+- Examples: "X terminal emulator is overrated because...", "The default config is bad and here's why", "This package manager war is stupid but I choose Y"
+- Signpost it clearly — don't sound accidentally angry. Make it intentional.
+- A purely informative, straightforward post is fine. Not everything needs a hot take.
+
+## Handoff Docs
+
+When an agent produces a project and hands it off for blog writing, the handoff doc goes in `.agents/handoffs/<slug>.md`. Format:
+
+```markdown
+# Handoff: <Topic>
+
+## What Was Built
+<summary>
+
+## Key Decisions
+- <decision> — <why>
+
+## Screenshots Available
+- <path> — <what it shows>
+
+## One Piece Angle Suggestion
+<character/theme>
+
+## Trivia / Hot Takes
+- <trivia fact>
+- <hot take>
+
+## Config Files / Dotfiles
+- <path> — <purpose>
+```
+
+The blog-writing agent reads this before drafting. Handoff docs keep project work and writing decoupled.
 
 ## Code Blocks
 
@@ -64,6 +142,7 @@ draft: false
 - Code blocks must be directly useful — copy-paste should work
 - Include comments (`# ...`) for brevity but keep commands runnable
 - For multi-service Docker Compose, show the service block, not the full file
+- For config file excerpts, show only the relevant section with a comment showing the file path
 
 ## Secrets & Placeholders
 
@@ -87,6 +166,8 @@ draft: false
 - Use `<div class="grid cards" markdown>` for feature comparison or spec lists
 - Only use inline styles when grid cards need custom icon coloring
 - For two images side by side, use a `<div class="grid" markdown>` with two `![...](...)` items
+- For trivia: `!!! tip "Trivia"` — one paragraph, directly relevant
+- For hot takes: `!!! quote "Hot Take"` — intentional, opinionated, signed with personality
 
 ## MkDocs Features Allowed
 

--- a/.agents/skills/write-blog-post.md
+++ b/.agents/skills/write-blog-post.md
@@ -5,13 +5,16 @@ When asked to write a new blog post for the Sanji site.
 
 ## Steps
 
-1. **Read reference posts** — read the 2 most recent posts in `docs/blog/posts/` to understand current style
-2. **Identify the pattern** — match the new post to one of the patterns in `.agents/patterns/blog-patterns.md`
-3. **Read the rules** — review `.agents/rules/blog-rules.md`
-4. **Draft the post** — place in `docs/blog/posts/<slug>.md`
-5. **Create image directory** — `docs/assets/images/<slug>/`
-6. **Run build** — `uv run poe build` to verify no errors
-7. **Clean up** — fix any warnings or errors
+1. **Read handoff doc (if available)** — check `.agents/handoffs/` for a matching slug. If found, read it — it contains key decisions, screenshots, OP angle, and trivia from the project work.
+2. **Read reference posts** — read the 2 most recent posts in `docs/blog/posts/` to understand current style
+3. **Identify the pattern** — match the new post to one of the patterns in `.agents/patterns/blog-patterns.md`
+4. **Read the rules** — review `.agents/rules/blog-rules.md`, especially the One Piece theming and trivia sections
+5. **Determine the OP angle** — pick a character/theme parallel (use the matrix in Pattern 4 if applicable)
+6. **Source images** — find OP intro + closing images, add any screenshots from the handoff doc
+7. **Draft the post** — place in `docs/blog/posts/<slug>.md`
+8. **Create image directory** — `docs/assets/images/<slug>/`
+9. **Run build** — `uv run poe build` to verify no errors
+10. **Clean up** — fix any warnings or errors
 
 ## Conventions
 
@@ -20,3 +23,5 @@ When asked to write a new blog post for the Sanji site.
 - Draft: set `draft: false` for ready posts, `true` for WIP
 - Image paths: `../../assets/images/<slug>/<filename>`
 - Always use `uv run poe build` (not raw `mkdocs build`)
+- Every post gets an OP intro image and OP closing image (mandatory). Thematic references in text are optional.
+- Trivia and hot takes are encouraged but not required — only include them if they add value

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "redhat.vscode-yaml",
+        "yzhang.markdown-all-in-one",
+        "bierner.markdown-mermaid",
+        "streetsidesoftware.code-spell-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,10 @@
         "Wano",
         "zeff",
         "Zoro"
+    ],
+    "yaml.customTags": [
+        "!!python/name:material.extensions.emoji.twemoji",
+        "!!python/name:material.extensions.emoji.to_svg",
+        "!!python/name:pymdownx.superfences.fence_code_format"
     ]
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: Sanji
 site_url: https://prateekrai-atlan.github.io/sanji/
 site_author: Prateek Rai
-site_description: Sanji is a personal website for Prateek Rai. It is a collection of blogs, personal opinions, and rants.
+site_description: Sanji — a personal site by Prateek Rai. Projects, blogs, rants, and a resume of sorts.
 copyright: >-
   Copyright &copy; 2025 Prateek Rai
 


### PR DESCRIPTION
## Summary

- Rewrote `.agents/commands/new-blog.md` as an executable workflow that accepts handoff docs
- Added **Pattern 4: Rant + One Piece** to `.agents/patterns/blog-patterns.md` for tooling/dotfiles posts
- Updated `.agents/rules/blog-rules.md` with One Piece theming strategy, trivia/rant guidelines, and handoff doc format
- Updated `.agents/skills/write-blog-post.md` to consume handoff docs
- Updated `.agents/AGENTS.md` with handoff workflow diagram
- Created `.agents/handoffs/` directory for decoupled project-to-blog handoffs
- Updated site description in `mkdocs.yml` to reflect personal site identity
- Added `.vscode/extensions.json` with recommended extensions (YAML, Markdown, Mermaid, spell check)
- Fixed `.vscode/settings.json` with `yaml.customTags` to suppress PyYAML lint warnings

Closes: _(not applicable — infrastructure change)_