### PR TITLE
feat: dracula theme, font swap, and code block lang tags

### DIFF
--- a/.agents/rules/blog-rules.md
+++ b/.agents/rules/blog-rules.md
@@ -137,9 +137,11 @@ The blog-writing agent reads this before drafting. Handoff docs keep project wor
 
 ## Code Blocks
 
-- Language tag required on every fenced code block
-- Prefer `bash` for shell commands, `yaml` for compose files, `powershell` for Windows
-- Code blocks must be directly useful — copy-paste should work
+- **Language tag REQUIRED on every fenced code block** — never leave `` ``` `` bare. Use ` ```bash `, ` ```yaml `, ` ```text `, etc.
+- Use `text` for non-code content: directory trees (`/srv/...`), UI navigation paths (`Settings → ...`), file listings, URLs — anything that's not executable
+- Prefer `bash` for shell commands, `yaml` for compose files, `powershell` for Windows, `ini` or `env` for config files
+- **Every block must have a language tag** — no exceptions. A bare `` ``` `` opening fence means no syntax highlighting.
+- Code blocks must be copy-paste ready — commands should work as written
 - Include comments (`# ...`) for brevity but keep commands runnable
 - For multi-service Docker Compose, show the service block, not the full file
 - For config file excerpts, show only the relevant section with a comment showing the file path

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,8 +12,12 @@
         "Zoro"
     ],
     "yaml.customTags": [
-        "!!python/name:material.extensions.emoji.twemoji",
-        "!!python/name:material.extensions.emoji.to_svg",
-        "!!python/name:pymdownx.superfences.fence_code_format"
+        "!ENV scalar",
+        "!ENV sequence",
+        "!relative scalar",
+        "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji scalar",
+        "tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg scalar",
+        "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format scalar",
+        "tag:yaml.org,2002:python/object/apply:pymdownx.slugs.slugify mapping"
     ]
 }

--- a/docs/blog/posts/aerial-views.md
+++ b/docs/blog/posts/aerial-views.md
@@ -63,7 +63,7 @@ graph LR
 
 ### 1. Enable Developer Options on the TV
 
-```
+```text
 Settings → Device Preferences → About → Build → click 7 times
 Settings → System → Developer options → USB debugging → ON
 ```
@@ -160,7 +160,7 @@ Google TV is 16:9 4K, so aim for **3840×2160** content:
 
 My TV now cycles through a mix of 4K Wallhaven images and a video loop from MoeWalls — about 151 MB of local content that plays regardless of internet connectivity.
 
-```
+```text
 /sdcard/AerialViews/
 ├── wallhaven-je86dy_3840x2160.png
 ├── wallhaven-d86o9g_3840x2160.png

--- a/docs/blog/posts/hermes.md
+++ b/docs/blog/posts/hermes.md
@@ -41,7 +41,7 @@ The server's 15-year-old hardware does not matter here. Hermes does not run a mo
 
 Hermes ships as an official Docker image, so it fits right into Ohara's existing infrastructure. I keep all app data under `/srv/appdata`, so Hermes lives at `/srv/appdata/hermes/`:
 
-```
+```text
 /srv/appdata/hermes/
 ├── docker-compose.yml
 ├── .env
@@ -73,7 +73,7 @@ services:
 
 The `.env` file beside the compose file holds just the OpenRouter key:
 
-```
+```bash
 OPENROUTER_API_KEY=sk-or-...
 ```
 

--- a/docs/blog/posts/ohara.md
+++ b/docs/blog/posts/ohara.md
@@ -151,7 +151,7 @@ sudo systemctl restart systemd-logind
 
 All data lives under `/srv`, following the Linux Filesystem Hierarchy Standard:
 
-```
+```text
 /srv/
 ├── media/
 │   ├── movies/
@@ -298,7 +298,7 @@ To add sources to Suwayomi:
 1. Log in with the credentials you set in `docker-compose.yml`
 2. Go to **Extensions** → **Repositories**
 3. Add the Keiyoushi extensions repository URL:
-   ```
+   ```text
    https://keiyoushi.github.io/extensions/index.json
    ```
 4. Click **Save** — the repository is now registered

--- a/docs/extra/css/dracula.css
+++ b/docs/extra/css/dracula.css
@@ -1,0 +1,139 @@
+/* Dracula Theme v1.0 — https://draculatheme.com
+   Color palette adapted for MkDocs Material by Prateek Rai.
+   Inspired by the Dracula Theme (draculatheme.com). */
+
+/* ── Dark Scheme ─────────────────────────────────────────── */
+
+[data-md-color-scheme="dracula-dark"] {
+  /* Primary = neutral dark header (not purple) */
+  --md-primary-fg-color: #21222c;
+  --md-primary-fg-color--light: #282a36;
+  --md-primary-fg-color--dark: #1d1e2b;
+  --md-primary-bg-color: #f8f8f2;
+  --md-primary-bg-color--light: #f8f8f280;
+
+  /* Accent = pink — used for hover, active, focus states */
+  --md-accent-fg-color: #ff79c6;
+  --md-accent-fg-color--transparent: #ff79c61a;
+  --md-accent-bg-color: #f8f8f2;
+  --md-accent-bg-color--light: #f8f8f280;
+
+  --md-default-fg-color: #f8f8f2;
+  --md-default-fg-color--light: #f8f8f2cc;
+  --md-default-fg-color--lighter: #f8f8f266;
+  --md-default-fg-color--lightest: #f8f8f21a;
+  --md-default-bg-color: #282a36;
+  --md-default-bg-color--light: #3a3c4a;
+  --md-default-bg-color--lighter: #44475a;
+  --md-default-bg-color--lightest: #44475a33;
+
+  --md-typeset-color: #f8f8f2;
+  --md-typeset-a-color: #8be9fd;
+  --md-typeset-mark-color: #f1fa8c80;
+
+  --md-code-fg-color: #f8f8f2;
+  --md-code-bg-color: #1d1e2b;
+  --md-code-hl-color: #44475a66;
+  --md-code-hl-number-color: #bd93f9;
+  --md-code-hl-special-color: #ff79c6;
+  --md-code-hl-function-color: #50fa7b;
+  --md-code-hl-constant-color: #ffb86c;
+  --md-code-hl-keyword-color: #ff79c6;
+  --md-code-hl-string-color: #f1fa8c;
+  --md-code-hl-name-color: #f8f8f2;
+  --md-code-hl-operator-color: #ff79c6;
+  --md-code-hl-punctuation-color: #f8f8f2;
+  --md-code-hl-comment-color: #6272a4;
+  --md-code-hl-generic-color: #f8f8f2;
+  --md-code-hl-variable-color: #f8f8f2;
+
+  --md-admonition-fg-color: #f8f8f2;
+  --md-admonition-bg-color: #282a36;
+
+  --md-footer-fg-color: #f8f8f2;
+  --md-footer-fg-color--light: #f8f8f280;
+  --md-footer-bg-color: #1d1e2b;
+  --md-footer-bg-color--dark: #21222c;
+
+  --md-typeset-table-color: #44475a;
+  --md-typeset-table-color--light: #44475a40;
+}
+
+/* ── Light Scheme ────────────────────────────────────────── */
+
+[data-md-color-scheme="dracula-light"] {
+  /* Primary = dark header on light page (GitHub-style) */
+  --md-primary-fg-color: #282a36;
+  --md-primary-fg-color--light: #3a3c4a;
+  --md-primary-fg-color--dark: #1d1e2b;
+  --md-primary-bg-color: #f8f8f2;
+  --md-primary-bg-color--light: #f8f8f280;
+
+  --md-accent-fg-color: #c0448b;
+  --md-accent-fg-color--transparent: #c0448b1a;
+  --md-accent-bg-color: #ffffff;
+  --md-accent-bg-color--light: #ffffff80;
+
+  --md-default-fg-color: #282a36;
+  --md-default-fg-color--light: #282a36cc;
+  --md-default-fg-color--lighter: #282a3666;
+  --md-default-fg-color--lightest: #282a361a;
+  --md-default-bg-color: #f8f8f2;
+  --md-default-bg-color--light: #ffffff;
+  --md-default-bg-color--lighter: #eae9e1;
+  --md-default-bg-color--lightest: #eae9e133;
+
+  --md-typeset-color: #282a36;
+  --md-typeset-a-color: #00b3cc;
+  --md-typeset-mark-color: #f1fa8c80;
+
+  --md-code-fg-color: #282a36;
+  --md-code-bg-color: #eae9e1;
+  --md-code-hl-color: #eae9e166;
+  --md-code-hl-number-color: #9266c2;
+  --md-code-hl-special-color: #c0448b;
+  --md-code-hl-function-color: #469b46;
+  --md-code-hl-constant-color: #b36200;
+  --md-code-hl-keyword-color: #c0448b;
+  --md-code-hl-string-color: #b8860b;
+  --md-code-hl-name-color: #282a36;
+  --md-code-hl-operator-color: #c0448b;
+  --md-code-hl-punctuation-color: #282a36;
+  --md-code-hl-comment-color: #7e8a9c;
+  --md-code-hl-generic-color: #282a36;
+  --md-code-hl-variable-color: #282a36;
+
+  --md-admonition-fg-color: #282a36;
+  --md-admonition-bg-color: #f8f8f2;
+
+  --md-footer-fg-color: #f8f8f2;
+  --md-footer-fg-color--light: #f8f8f280;
+  --md-footer-bg-color: #282a36;
+  --md-footer-bg-color--dark: #1d1e2b;
+
+  --md-typeset-table-color: #eae9e1;
+  --md-typeset-table-color--light: #eae9e140;
+}
+
+/* ── Tab Navigation (both schemes) ──────────────────────── */
+
+.md-tabs__link {
+  color: var(--md-primary-bg-color);
+  opacity: 0.7;
+}
+
+.md-tabs__link:hover {
+  color: var(--md-accent-fg-color);
+  opacity: 1;
+}
+
+.md-tabs__link--active {
+  color: var(--md-accent-fg-color);
+  opacity: 1;
+}
+
+/* Active tab underline indicator */
+.md-tabs__item--active .md-tabs__link {
+  color: var(--md-accent-fg-color);
+  border-bottom: 2px solid var(--md-accent-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
+
 # Site Information
 site_name: Sanji
 site_url: https://prateekrai-atlan.github.io/sanji/
@@ -16,8 +18,8 @@ theme:
   language: en
   custom_dir: overrides
   font:
-    text: Google Sans Code
-    code: Google Sans Code
+    text: JetBrains Mono
+    code: JetBrains Mono
   favicon: logos/strawhat.png
   icon:
     logo: logos/strawhat
@@ -44,7 +46,6 @@ theme:
     # - navigation.tabs.sticky
     - navigation.top
     - navigation.tracking
-    - navigation.indexes
     - search.highlight
     - search.share
     - search.suggest
@@ -52,20 +53,17 @@ theme:
     # - toc.integrate
   palette:
     - media: "(prefers-color-scheme)"
+      scheme: dracula-dark
       toggle:
         icon: material/brightness-auto
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: black
-      accent: gray
+      scheme: dracula-light
       toggle:
         icon: material/weather-sunny
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: black
-      accent: gray
+      scheme: dracula-dark
       toggle:
         icon: material/weather-night
         name: Switch to system preference
@@ -102,6 +100,10 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+
+# Extra CSS
+extra_css:
+  - extra/css/dracula.css
 
 # Extra Configuration
 extra:


### PR DESCRIPTION
## Summary

- **Dracula theme**: Added `docs/extra/css/dracula.css` with custom CSS variable overrides for both dark and light schemes. Primary header is neutral dark (not purple) — accent pink used for active/hovered tabs.
- **Font**: Switched to JetBrains Mono (text + code) via Google Fonts.
- **Code block fixes**: Added missing language tags (`text`, `bash`) to 6 code blocks across all 3 blog posts for proper syntax highlighting.
- **Agent rules**: Strengthened code block language tag rule — `text` for directory trees/UI paths/URLs.
- **VS Code settings**: Updated `yaml.customTags` per official Material docs format.