### PR TITLE
feat: dev.to syndication script and CI workflow

### DIFF
--- a/.github/workflows/syndicate.yml
+++ b/.github/workflows/syndicate.yml
@@ -1,0 +1,59 @@
+name: Syndicate blog to dev.to
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  syndicate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Detect changed blog posts
+        id: changed
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            FILES=$(git diff-tree --no-commit-id -r "${{ github.sha }}" --name-only -- 'docs/blog/posts/*.md')
+          else
+            FILES=$(git diff --name-only "$BEFORE" "${{ github.sha }}" -- 'docs/blog/posts/*.md')
+          fi
+          FILES=$(echo "$FILES" | grep -v 'sanji\.md$' || true)
+          {
+            echo "changed<<DELIM"
+            echo "$FILES"
+            echo "DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Syndicate to dev.to
+        if: steps.changed.outputs.changed != ''
+        run: |
+          echo "$CHANGED_FILES" | while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            echo "→ Syndicating $file"
+            uv run python scripts/syndicate.py "$file" --publish
+          done
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.changed }}
+          DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
+
+      - name: No blog changes
+        if: steps.changed.outputs.changed == ''
+        run: echo "No blog posts changed — skipped"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.env
 .cache
 site/
 .agents/handoffs/*.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "mkdocs-material[imaging]>=9.6.14,<10",
     "mkdocs-rss-plugin>=1.17.7",
     "poethepoet>=0.34",
+    "python-dotenv>=1.1,<2",
+    "requests>=2.32,<3",
 ]
 
 [tool.poe.tasks]

--- a/scripts/syndicate.py
+++ b/scripts/syndicate.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Syndicate a Sanji blog post to dev.to.
+
+Usage:
+    # Draft (default) — creates as unpublished, safe to inspect on dev.to
+    python scripts/syndicate.py docs/blog/posts/hermes.md
+
+    # Publish immediately
+    python scripts/syndicate.py docs/blog/posts/hermes.md --publish
+
+    # Update an existing article (pass its dev.to ID)
+    python scripts/syndicate.py docs/blog/posts/hermes.md --update 12345
+
+    # Preview the payload without sending
+    python scripts/syndicate.py docs/blog/posts/hermes.md --dry-run
+
+Environment (in order of precedence):
+    DEVTO_API_KEY  (or .env file in project root)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import zlib
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print("error: `requests` is required — run: uv add requests", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    load_dotenv = None  # optional
+
+
+RAW_BASE = "https://raw.githubusercontent.com/prateek11rai/sanji/main"
+SITE_BASE = "https://prateek11rai.github.io/sanji"
+DEVTO_API = "https://dev.to/api/articles"
+MAX_TAGS = 4
+
+
+def parse_front_matter(content: str) -> tuple[dict, str]:
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
+    if not match:
+        return {}, content
+
+    raw = match.group(1)
+    body = content[match.end() :]
+    fm: dict = {}
+
+    cats = re.search(r"^categories:\s*\n((?:\s+- .+\n?)+)", raw, re.MULTILINE)
+    if cats:
+        fm["categories"] = re.findall(r"\s+- (.+)", cats.group(1))
+
+    dt = re.search(r"^date:\s*(.+)", raw, re.MULTILINE)
+    if dt:
+        fm["date"] = dt.group(1).strip()
+
+    draft = re.search(r"^draft:\s*(.+)", raw, re.MULTILINE)
+    fm["draft"] = draft and draft.group(1).strip().lower() == "true"
+
+    return fm, body
+
+
+def extract_title(body: str) -> str | None:
+    m = re.search(r"^# (.+)", body, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+def extract_description(body: str, max_chars: int = 200) -> str | None:
+    text = re.sub(r"^# .+\n*", "", body, count=1).strip()
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("![") or line.startswith("<!--") or line.startswith("<"):
+            continue
+        if line.startswith("[^") and line.endswith("]:"):
+            continue
+        clean = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", line)
+        clean = re.sub(r"\*\*([^*]+)\*\*", r"\1", clean)
+        clean = re.sub(r"\*([^*]+)\*", r"\1", clean)
+        clean = re.sub(r"`([^`]+)`", r"\1", clean)
+        clean = re.sub(r"\[\^\d+\]", "", clean).rstrip(".").strip()
+        if len(clean) > max_chars:
+            clean = clean[: max_chars - 3] + "..."
+        return clean or None
+    return None
+
+
+def extract_first_image(body: str) -> str | None:
+    m = re.search(r"!\[.*?\]\((.+?)\)", body)
+    return m.group(1).strip() if m else None
+
+
+# ---------------------------------------------------------------------------
+# Transformers — applied in order
+# ---------------------------------------------------------------------------
+
+def _replace_image_urls(body: str) -> str:
+    def _repl(m: re.Match) -> str:
+        alt, url = m.group(1), m.group(2)
+        if url.startswith("../../"):
+            url = f"{RAW_BASE}/docs/{url[6:]}"
+        elif url.startswith("../"):
+            url = f"{RAW_BASE}/docs/{url[3:]}"
+        return f"![{alt}]({url})"
+
+    return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", _repl, body)
+
+
+def _strip_loading_lazy(body: str) -> str:
+    return re.sub(r"\{\s*loading\s*=\s*lazy\s*\}", "", body)
+
+
+def _strip_more_tag(body: str) -> str:
+    return re.sub(r"<!-- more -->\s*\n*", "", body)
+
+
+def _strip_footnote_refs(body: str) -> str:
+    return re.sub(r"\[\^\d+\]", "", body)
+
+
+def _unwrap_footnote_defs(body: str) -> str:
+    lines = body.split("\n")
+    kept: list[str] = []
+    footnotes: list[str] = []
+    for line in lines:
+        if re.match(r"^\[\^\d+\]:\s*", line):
+            footnotes.append(re.sub(r"^\[\^\d+\]:\s*", "", line))
+        else:
+            kept.append(line)
+    if footnotes:
+        kept.append("")
+        kept.append("---")
+        kept.append("")
+        kept.extend(footnotes)
+    return "\n".join(kept)
+
+
+def _strip_html_styles(body: str) -> str:
+    return re.sub(r"<style>.*?</style>", "", body, flags=re.DOTALL)
+
+
+def _render_mermaid(body: str) -> str:
+    def _repl(m: re.Match) -> str:
+        code = m.group(1).strip()
+        payload = json.dumps({
+            "code": code,
+            "mermaid": json.dumps({"theme": "neutral"}),
+            "updateEditor": False,
+            "autoSync": False,
+            "updateDiagram": True,
+        }, separators=(",", ":"))
+        compressed = zlib.compress(payload.encode(), level=9)
+        encoded = base64.urlsafe_b64encode(compressed).decode().rstrip("=")
+        url = f"https://mermaid.ink/img/pako:{encoded}"
+        return f"![Architecture diagram]({url})\n"
+    return re.sub(
+        r"```mermaid\n(.*?)```\s*\n*",
+        _repl,
+        body,
+        flags=re.DOTALL,
+    )
+
+
+def _strip_grid_divs(body: str) -> str:
+    body = re.sub(r'<div[^>]*>', "", body)
+    body = re.sub(r"</div>", "", body)
+    return body
+
+
+def _strip_mkdocs_attrs(body: str) -> str:
+    return re.sub(r"\{\s*\.[a-zA-Z0-9_-]+[\s,.]*[a-zA-Z0-9_-]*\s*\}", "", body)
+
+
+def _convert_admonitions(body: str) -> str:
+    def _repl(m: re.Match) -> str:
+        t = m.group(1).strip()
+        title_raw = m.group(2)
+        content = m.group(3)
+        heading = title_raw.strip("\" ") if title_raw else t.title()
+        lines = [f"> **{heading}**"]
+        for cl in content.split("\n"):
+            stripped = cl.strip()
+            if stripped:
+                lines.append(f"> {stripped}")
+            else:
+                lines.append(">")
+        return "\n".join(lines)
+
+    return re.sub(
+        r"!!!\s+(\w+)\s*(\"[^\"]*\")?\s*\n((?:\s{4}[^\n]*\n?)*)",
+        _repl,
+        body,
+    )
+
+
+def _replace_icons(body: str) -> str:
+    body = re.sub(r":material-check-circle:", "✅", body)
+    body = re.sub(r":material-cigar:", "🚬", body)
+    body = re.sub(r":material-desktop-tower:", "🖥️", body)
+    body = re.sub(r":material-checkbox-marked-circle:", "✅", body)
+    body = re.sub(r":material-[a-z_-]+:", "", body)
+    body = re.sub(r":simple-[a-z_-]+:", "", body)
+    return body
+
+
+def _strip_h1(body: str) -> str:
+    return re.sub(r"^# .+\n*", "", body, count=1).strip() + "\n"
+
+
+def transform_body(body: str) -> str:
+    body = _strip_more_tag(body)
+    body = _strip_html_styles(body)
+    body = _strip_grid_divs(body)
+    body = _render_mermaid(body)
+    body = _strip_loading_lazy(body)
+    body = _strip_mkdocs_attrs(body)
+    body = _replace_icons(body)
+    body = _convert_admonitions(body)
+    body = _replace_image_urls(body)
+    body = _unwrap_footnote_defs(body)
+    body = _strip_footnote_refs(body)
+    body = _strip_h1(body)
+    return body.strip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Payload builder
+# ---------------------------------------------------------------------------
+
+def make_slug(title: str) -> str:
+    try:
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from pymdownx.slugs import uslugify
+            return uslugify(title, "-")
+    except ImportError:
+        return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def build_payload(post_file: Path, slug: str | None = None, publish: bool = False) -> dict:
+    content = post_file.read_text(encoding="utf-8")
+    fm, body = parse_front_matter(content)
+
+    title = extract_title(body) or slug or post_file.stem.replace("-", " ").title()
+    description = extract_description(body)
+    raw_image = extract_first_image(body)
+    slug = slug or make_slug(title)
+
+    tags = [t.lower() for t in fm.get("categories", [])][:MAX_TAGS]
+    if not tags:
+        tags = ["meta"]
+
+    date_str = fm.get("date", "")
+    date_parts = date_str.split("-")
+    if len(date_parts) == 3:
+        canonical_url = f"{SITE_BASE}/blog/{date_parts[0]}/{date_parts[1]}/{date_parts[2]}/{slug}/"
+    else:
+        canonical_url = f"{SITE_BASE}/blog/{slug}/"
+
+    main_image_url = None
+    if raw_image:
+        if raw_image.startswith("../../"):
+            main_image_url = f"{RAW_BASE}/docs/{raw_image[6:]}"
+        elif raw_image.startswith("../"):
+            main_image_url = f"{RAW_BASE}/docs/{raw_image[3:]}"
+        else:
+            main_image_url = raw_image
+
+    should_publish = publish and not fm.get("draft", False)
+
+    body_markdown = transform_body(body)
+
+    return {
+        "article": {
+            "title": title,
+            "body_markdown": body_markdown,
+            "published": should_publish,
+            "canonical_url": canonical_url,
+            "description": description or "",
+            "tags": ", ".join(tags),
+            "main_image": main_image_url,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def find_existing(api_key: str, canonical_url: str) -> int | None:
+    """Return dev.to article ID if one with this canonical_url already exists."""
+    headers = {"api-key": api_key}
+    for url in [
+        f"{DEVTO_API}/me/all?per_page=100",
+        f"{DEVTO_API}/me/published?per_page=100",
+    ]:
+        resp = requests.get(url, headers=headers)
+        if resp.status_code != 200:
+            continue
+        for article in resp.json():
+            if article.get("canonical_url") == canonical_url:
+                return article["id"]
+    return None
+
+
+def fetch_article(api_key: str, article_id: int) -> dict | None:
+    """Fetch article metadata from dev.to (works for drafts too)."""
+    resp = requests.get(
+        f"{DEVTO_API}/me/all?per_page=100",
+        headers={"api-key": api_key},
+    )
+    if resp.status_code != 200:
+        return None
+    for article in resp.json():
+        if article["id"] == article_id:
+            return article
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Syndicate a Sanji blog post to dev.to",
+    )
+    parser.add_argument("post_file", type=Path, help="Path to the markdown blog post")
+    parser.add_argument("--publish", action="store_true", help="Publish immediately (default: draft)")
+    parser.add_argument("--dry-run", action="store_true", help="Print payload and exit")
+    parser.add_argument("--update", type=int, metavar="ID", default=None,
+                        help="Update article by dev.to ID (auto-detected if omitted)")
+    parser.add_argument("--slug", help="Override the URL slug (default: filename stem)")
+    parser.add_argument(
+        "--force-new", action="store_true",
+        help="Skip duplicate check and create a new article",
+    )
+    args = parser.parse_args()
+
+    if load_dotenv:
+        load_dotenv()
+
+    api_key = os.environ.get("DEVTO_API_KEY")
+    if not api_key:
+        print("error: DEVTO_API_KEY not set — add to .env or export it", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.post_file.exists():
+        print(f"error: file not found — {args.post_file}", file=sys.stderr)
+        sys.exit(1)
+
+    payload = build_payload(args.post_file, slug=args.slug, publish=args.publish)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return
+
+    headers = {"api-key": api_key, "Content-Type": "application/json"}
+
+    existing_id = args.update
+    if existing_id is None and not args.force_new:
+        canonical_url = payload["article"]["canonical_url"]
+        existing_id = find_existing(api_key, canonical_url)
+        if existing_id:
+            print(f"ℹ existing article found (ID {existing_id}) — updating")
+
+    if existing_id:
+        existing = fetch_article(api_key, existing_id)
+        if existing is not None and not args.publish:
+            payload["article"]["published"] = existing.get("published", False)
+        url = f"{DEVTO_API}/{existing_id}"
+        resp = requests.put(url, headers=headers, json=payload)
+    else:
+        resp = requests.post(DEVTO_API, headers=headers, json=payload)
+
+    if resp.status_code in (200, 201):
+        result = resp.json()
+        print(f"✅ {result.get('url', result.get('title', 'published'))}")
+    else:
+        print(f"❌ {resp.status_code} — {resp.text}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -70,11 +70,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.4.22"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -127,14 +127,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -170,11 +170,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -215,11 +215,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -365,19 +365,21 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "1.1.2"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
-    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
-    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
 ]
 
 [[package]]
@@ -437,24 +439,24 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
 name = "poethepoet"
-version = "0.45.0"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pastel" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/28/d54e16913f591f01b2e1c4ab526ccbba47864d9bf10299904c823a760d25/poethepoet-0.45.0.tar.gz", hash = "sha256:cf2c2df4c185d33b619c2771de2b28c2b81c733f072226030c7fa4c273c040f8", size = 97150, upload-time = "2026-04-28T21:04:59.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/ec/0e80a71d3ea9fbbd0f419cd0f33c46bab0a19bbf65dacce96edf72dd09cd/poethepoet-0.47.0.tar.gz", hash = "sha256:8902da95e78ecec6bf1ee37b7c4da3bcf53f2ff89eb0d8a4447c01de4c4f2e6e", size = 145693, upload-time = "2026-06-27T14:00:46.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/99/4aefb693b0f52783fab496492f4444a75137312c386eb7c3320f1b0a1602/poethepoet-0.45.0-py3-none-any.whl", hash = "sha256:8e25f6e834ecf25fe2ddca676a4e0207eeb2e19def0a8709fc5c7f18e86cd68c", size = 123920, upload-time = "2026-04-28T21:04:57.66Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d3/419673fea140c243a8ed35022b92b355787dd565d2318dfab940b2a96b91/poethepoet-0.47.0-py3-none-any.whl", hash = "sha256:b443f38c5c8cd6e2415bcd5922a45c03ab120360ff0d515233ef6279f3f285c3", size = 183561, upload-time = "2026-06-27T14:00:45.031Z" },
 ]
 
 [[package]]
@@ -500,15 +502,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
 ]
 
 [[package]]
@@ -521,6 +523,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -555,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -563,9 +574,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -577,6 +588,8 @@ dependencies = [
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "mkdocs-rss-plugin" },
     { name = "poethepoet" },
+    { name = "python-dotenv" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -585,6 +598,8 @@ requires-dist = [
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.6.14,<10" },
     { name = "mkdocs-rss-plugin", specifier = ">=1.17.7" },
     { name = "poethepoet", specifier = ">=0.34" },
+    { name = "python-dotenv", specifier = ">=1.1,<2" },
+    { name = "requests", specifier = ">=2.32,<3" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a Python script to syndicate MkDocs blog posts to dev.to, along with a GitHub Actions workflow that auto-runs on push to main.

- **scripts/syndicate.py** — full transformation pipeline: front matter parsing, footnote handling, Mermaid→mermaid.ink images, canonical URL support, idempotent create/update via dev.to API
- **.github/workflows/syndicate.yml** — detects changed blog posts on each push to main, runs syndicate only for new/modified posts, skips sanji.md, marks success when no blog changes
- Adds  and  dependencies
- Adds  to gitignore