### PR TITLE
fix: send tags as array and strip hyphens for dev.to API

### DIFF
--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,1 @@
+DEVTO_API_KEY=

--- a/scripts/syndicate.py
+++ b/scripts/syndicate.py
@@ -258,7 +258,7 @@ def build_payload(post_file: Path, slug: str | None = None, publish: bool = Fals
     raw_image = extract_first_image(body)
     slug = slug or make_slug(title)
 
-    tags = [t.lower() for t in fm.get("categories", [])][:MAX_TAGS]
+    tags = [t.lower().replace("-", "") for t in fm.get("categories", [])][:MAX_TAGS]
     if not tags:
         tags = ["meta"]
 
@@ -289,7 +289,7 @@ def build_payload(post_file: Path, slug: str | None = None, publish: bool = Fals
             "published": should_publish,
             "canonical_url": canonical_url,
             "description": description or "",
-            "tags": ", ".join(tags),
+            "tags": tags,
             "main_image": main_image_url,
         }
     }


### PR DESCRIPTION
Two bugs in tag handling:

1. Tags were sent as a comma-separated string — dev.to API expects an array
2. Hyphens in category names (e.g. `Self-Hosting`) were not stripped — dev.to rejects tags with non-alphanumeric characters

Changes in `scripts/syndicate.py`:
- `", ".join(tags)` → `tags` (send raw list)
- `t.lower()` → `t.lower().replace("-", "")` (strip hyphens)
