### PR TITLE
fix: ensure blank line after admonition blockquote

### DIFF
--- a/scripts/syndicate.py
+++ b/scripts/syndicate.py
@@ -186,7 +186,7 @@ def _convert_admonitions(body: str) -> str:
     def _repl(m: re.Match) -> str:
         t = m.group(1).strip()
         title_raw = m.group(2)
-        content = m.group(3)
+        content = m.group(3).strip("\n")
         heading = title_raw.strip("\" ") if title_raw else t.title()
         lines = [f"> **{heading}**"]
         for cl in content.split("\n"):
@@ -195,7 +195,7 @@ def _convert_admonitions(body: str) -> str:
                 lines.append(f"> {stripped}")
             else:
                 lines.append(">")
-        return "\n".join(lines)
+        return "\n".join(lines) + "\n"
 
     return re.sub(
         r"!!!\s+(\w+)\s*(\"[^\"]*\")?\s*\n((?:\s{4}[^\n]*\n?)*)",


### PR DESCRIPTION
Headings after `!!! quote` admonitions were bleeding into the blockquote on dev.to — the replacement text lacked a trailing newline, so the blank line after the blockquote was consumed.

Change in `scripts/syndicate.py`:
- `return "\n".join(lines)` → `return "\n".join(lines) + "\n"`