### PR TITLE
feat: add tags front matter to all posts for dev.to

### DIFF
--- a/.agents/rules/blog-rules.md
+++ b/.agents/rules/blog-rules.md
@@ -12,13 +12,17 @@ authors:
     - prateek11rai
 categories:
   - CategoryName
+tags:
+  - tag1
+  - tag2
 date: YYYY-MM-DD
 draft: false
 ---
 ```
 
 - Only one author: `prateek11rai`
-- Categories: 1-2 max, PascalCase (e.g. `Self-Hosting`, `Homelab`, `Anime`, `AI`, `Tooling`)
+- Categories: 1-2 max, PascalCase, for site navigation (e.g. `Self-Hosting`, `Homelab`, `Anime`, `AI`, `Tooling`)
+- Tags: 1-4, lowercase, no hyphens or special chars, for dev.to discovery (e.g. `wezterm`, `tmux`, `terminal`, `selfhosting`). These are ignored by MkDocs but used by the syndication script. If omitted, the script falls back to categories.
 - Date: use the actual publication date
 - Never leave `draft: true` for published posts
 

--- a/docs/blog/posts/aerial-views.md
+++ b/docs/blog/posts/aerial-views.md
@@ -4,6 +4,11 @@ authors:
 categories:
   - Android
   - Homelab
+tags:
+  - android
+  - homelab
+  - screensaver
+  - google
 date: 2026-05-17
 draft: false
 ---

--- a/docs/blog/posts/devto-syndication.md
+++ b/docs/blog/posts/devto-syndication.md
@@ -3,6 +3,11 @@ authors:
     - prateek11rai
 categories:
   - Tooling
+tags:
+  - devto
+  - ci
+  - seo
+  - python
 date: 2026-06-28
 draft: false
 ---

--- a/docs/blog/posts/hermes.md
+++ b/docs/blog/posts/hermes.md
@@ -4,6 +4,11 @@ authors:
 categories:
   - Self-Hosting
   - AI
+tags:
+  - selfhosting
+  - ai
+  - llm
+  - hermes
 date: 2026-05-17
 draft: false
 ---

--- a/docs/blog/posts/ohara.md
+++ b/docs/blog/posts/ohara.md
@@ -4,6 +4,11 @@ authors:
 categories:
   - Self-Hosting
   - Homelab
+tags:
+  - selfhosting
+  - homelab
+  - jellyfin
+  - tailscale
 date: 2026-05-10
 draft: false
 ---

--- a/docs/blog/posts/wezterm-tmux-setup.md
+++ b/docs/blog/posts/wezterm-tmux-setup.md
@@ -3,6 +3,11 @@ authors:
     - prateek11rai
 categories:
   - Tooling
+tags:
+  - wezterm
+  - tmux
+  - terminal
+  - dotfiles
 date: 2026-06-06
 draft: false
 ---

--- a/scripts/syndicate.py
+++ b/scripts/syndicate.py
@@ -60,6 +60,10 @@ def parse_front_matter(content: str) -> tuple[dict, str]:
     if cats:
         fm["categories"] = re.findall(r"\s+- (.+)", cats.group(1))
 
+    tags = re.search(r"^tags:\s*\n((?:\s+- .+\n?)+)", raw, re.MULTILINE)
+    if tags:
+        fm["tags"] = re.findall(r"\s+- (.+)", tags.group(1))
+
     dt = re.search(r"^date:\s*(.+)", raw, re.MULTILINE)
     if dt:
         fm["date"] = dt.group(1).strip()
@@ -258,7 +262,7 @@ def build_payload(post_file: Path, slug: str | None = None, publish: bool = Fals
     raw_image = extract_first_image(body)
     slug = slug or make_slug(title)
 
-    tags = [t.lower().replace("-", "") for t in fm.get("categories", [])][:MAX_TAGS]
+    tags = [t.lower().replace("-", "") for t in fm.get("tags") or fm.get("categories", [])][:MAX_TAGS]
     if not tags:
         tags = ["meta"]
 


### PR DESCRIPTION
Adds an explicit `tags:` field to all blog posts for better dev.to discoverability, separate from `categories` used for site nav.

Posts updated:
- ohara.md → selfhosting, homelab, jellyfin, tailscale
- hermes.md → selfhosting, ai, llm, hermes
- aerial-views.md → android, homelab, screensaver, google
- wezterm-tmux-setup.md → wezterm, tmux, terminal, dotfiles

Also updates `.agents/rules/blog-rules.md` to include `tags:` in front matter template, and `scripts/syndicate.py` to read `tags` first (falling back to `categories`).