### PR TITLE
fix: correct site_url host (social cards 404'd)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 
 # Site Information
 site_name: Sanji
-site_url: https://prateekrai-atlan.github.io/sanji/
+site_url: https://prateek11rai.github.io/sanji/
 site_author: Prateek Rai
 site_description: Sanji — a personal site by Prateek Rai. Projects, blogs, rants, and a resume of sorts.
 copyright: >-


### PR DESCRIPTION
One-line fix: `site_url` pointed at the old `prateekrai-atlan.github.io` account, so `og:image`, `og:url`, canonical links, and the sitemap all carried a dead host. X/Twitter fetched the card, got a 404 on the image, and fell back to the text-only card. Verified locally that og:image now resolves to prateek11rai.github.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)