### PR TITLE
fix: social cards use Dracula theme colors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,10 @@ plugins:
       enabled: true
   - social:
       enabled: true
+      cards_layout_options:
+        background_color: "#21222c"
+        color: "#f8f8f2"
+        font_family: JetBrains Mono
   - blog:
       authors: true
       draft_on_serve: true


### PR DESCRIPTION
Social cards were using the default mkdocs-material indigo (#4051b5) background because the palette entries only set `scheme` (CSS class name) without `primary` or `accent`. The card renderer reads `palette.primary`, finds nothing, and falls back to `"indigo"`.

**Fix:** Added `cards_layout_options` to the social plugin config with explicit Dracula colors:
- `background_color: "#21222c"` — Dracula dark background  
- `color: "#f8f8f2"` — Dracula foreground  
- `font_family: JetBrains Mono` — matches site font

Verified after rebuild: background is exactly `#21222c` (previously `#4051b5`), text is `#f8f8f2` (previously `#ffffff`).